### PR TITLE
starting to move exports into the zshenv

### DIFF
--- a/symlinks/install.sh
+++ b/symlinks/install.sh
@@ -17,6 +17,12 @@ if [[ ! -L ~/.zshrc ]]; then
     ln -s $DOTFILES/symlinks/zsh/zshrc.sh ~/.zshrc
 fi
 
+debug "Verifying ~/.zshenv symlink"
+if [[ ! -L ~/.zshenv ]]; then
+	echo "Symlinking ~/.zshenv"
+    ln -s $DOTFILES/symlinks/zsh/zshenv.sh ~/.zshenv
+fi
+
 debug "Verifying ~/.oh-my-zsh/themes/smt-mod.zsh-theme symlink"
 if [[ ! -L ~/.oh-my-zsh/themes/smt-mod.zsh-theme ]]; then
 	echo "Symlinking ~/.oh-my-zsh/themes/smt-mod.zsh-theme"

--- a/symlinks/zsh/README.md
+++ b/symlinks/zsh/README.md
@@ -1,0 +1,13 @@
+# ZSH
+
+### Loading order
+
+Zsh read these files in the following order:
+
+1. `~/.zshenv` - Should only contain user’s environment variables.
+1. `~/.zprofile` - Can be used to execute commands just after logging in.
+1. `~/.zshrc` - Should be used for the shell configuration and for executing commands.
+1. `~/.zlogin` - Same purpose than .zprofile, but read just after .zshrc.
+1. `~/.zlogout` - Can be used to execute commands when a shell exit.
+
+[source - thevaluable.dev](https://thevaluable.dev/zsh-install-configure-mouseless/)

--- a/symlinks/zsh/zshenv.sh
+++ b/symlinks/zsh/zshenv.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env zsh
+# zshenv
+
+DOTFILES=${DOTFILES:=~/dotfiles}
+
+# source the dotfiles/exports
+# Adding `(DN)` is a zsh option that includes dotfiles
+# https://unix.stackexchange.com/a/504718/107211
+for file in ${DOTFILES}/exports/*(DN); do
+    if [[ ! -d $file ]] && [[ `basename $file` != "index.sh" ]] && [[ `basename $file` != "README.md" ]]; then
+        source "$file"
+    fi
+done

--- a/symlinks/zsh/zshrc.sh
+++ b/symlinks/zsh/zshrc.sh
@@ -41,7 +41,7 @@ source $ZSH/oh-my-zsh.sh
 [[ -r ~/dotfiles/exports/path/PATH.sh ]] && source ~/dotfiles/exports/path/PATH.sh
 
 # source all files in the exports directory
-[[ -r ~/dotfiles/exports/index.sh ]] && source ~/dotfiles/exports/index.sh
+# [[ -r ~/dotfiles/exports/index.sh ]] && source ~/dotfiles/exports/index.sh
 
 # source all functions in the exports directory
 [[ -r ~/dotfiles/functions/install.sh ]] && source ~/dotfiles/functions/install.sh


### PR DESCRIPTION
Starting this as an PR while I test this out. It occurred to me that having an entire separate folder for `exports` completely ignores the use of the `~/.zshenv` file, but I like having the exports so explicit. And I don't like the idea of them getting buried in `symlinks/zsh` or `symlinks/exports`. I'll keep this here and think about it.